### PR TITLE
Replace deprecated constants

### DIFF
--- a/sudo/plugins/sudoers/auth/sudo_auth.m
+++ b/sudo/plugins/sudoers/auth/sudo_auth.m
@@ -492,9 +492,9 @@ touchid_verify(struct passwd *pw, char *pass, sudo_auth *auth, struct sudo_conv_
         [context evaluatePolicy:(result != kTouchIDResultFallback ? kAuthPolicy : kAuthPolicyFallback) localizedReason:@"authenticate a privileged operation" reply:^(BOOL success, NSError *error) {
             result = success ? kTouchIDResultAllowed : kTouchIDResultFailed;
             switch (error.code) {
-                case LAErrorTouchIDLockout:
-                case LAErrorTouchIDNotEnrolled:
-                case LAErrorTouchIDNotAvailable:
+                case LAErrorBiometryLockout:
+                case LAErrorBiometryNotEnrolled:
+                case LAErrorBiometryNotAvailable:
                 case LAErrorUserFallback:
                 case LAErrorAuthenticationFailed:
                     result = kTouchIDResultFallback;


### PR DESCRIPTION
To shutdown warnings because of the usage of deprecated constants (since 10.13) we use the newer constants that were introduced in 10.13.

As our deployment target is 10.13, there is no need for conditional compilation to support 10.12 and lower.